### PR TITLE
Add css to fix overflow bug

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://postgresgallery.netlify.com/"
+baseURL = "https://postgresgallery.netlify.com/"
 languageCode = "en-us"
 title = "PostgreSQL Gallery"
 theme = "ananke"

--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,5 @@ baseURL = "http://postgresgallery.netlify.com/"
 languageCode = "en-us"
 title = "PostgreSQL Gallery"
 theme = "ananke"
+[params]
+    custom_css = ["css/code-overflow.css"]

--- a/static/css/code-overflow.css
+++ b/static/css/code-overflow.css
@@ -1,0 +1,3 @@
+.highlight .pre,pre {
+  overflow: auto;
+}


### PR DESCRIPTION
Adding a custom_css param to the config.toml file
allowed me to include custom css to override the theme's css.

![overflow-bug-fix](https://user-images.githubusercontent.com/26194273/47959445-7832c000-e01f-11e8-89e8-dc00740a2822.png)

This works for all files, not just the example.md.
Fixes #3